### PR TITLE
Fix: Prevent list auto-creation during IME composition

### DIFF
--- a/src/components/compose.jsx
+++ b/src/components/compose.jsx
@@ -2324,7 +2324,7 @@ const Textarea = forwardRef((props, ref) => {
           // Get line before cursor position after pressing 'Enter'
           const { key, target } = e;
           const hasTextExpander = hasTextExpanderRef.current;
-          if (key === 'Enter' && !(e.ctrlKey || e.metaKey || hasTextExpander)) {
+          if (key === 'Enter' && !(e.ctrlKey || e.metaKey || hasTextExpander) && !e.isComposing) {
             try {
               const { value, selectionStart } = target;
               const textBeforeCursor = value.slice(0, selectionStart);


### PR DESCRIPTION
This commit fixes a bug where the composer would automatically create a new list item when pressing Enter during IME composition. The fix involves checking the  property of the keyboard event to prevent this behavior.